### PR TITLE
array merge was duplicating existing output params

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -236,7 +236,7 @@ class extension_association_output extends Extension
 
             // Add missing output parameters
             $fields = array_keys($associations);
-            $datasource->dsParamPARAMOUTPUT = array_merge($datasource->dsParamPARAMOUTPUT, $fields);
+            $datasource->dsParamPARAMOUTPUT = array_unique(array_merge($datasource->dsParamPARAMOUTPUT, $fields));
         }
     }
 


### PR DESCRIPTION
This would cause a performance issue, as it would duplicate all the output parameters, so in my case checking what `dsParamPARAMOUTPUT` was returning the following:

    array(
        'date',
        'article',
        'article'
    )

Thus running the same snippet of code twice, additionally it was also duplicating the output parameters, as seen below.

![screen shot 2015-02-26 at 08 28 09](https://cloud.githubusercontent.com/assets/859775/6388233/ce9a15aa-bd97-11e4-998f-54e65eb4bf83.png)