### PR TITLE
Add Post Execute Delegate

### DIFF
--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -13,6 +13,10 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="1.2.0" date="2015-08-25" min="2.5">
+			- Added a datasource property which when set will not run the association output (useful for caching)
+			- Add AssociationOutputPostExecute delegate so other extensions can take actions after the Association Output is added to the XML
+		</release>
 		<release version="1.1.0" date="2015-06-12" min="2.5">
 			- Added Cacheable Data Source support
 			- #10: Fixed handling of sections without fields (thanks @tonyarnold!)


### PR DESCRIPTION
Add postExecute delegate, as the cacheable datasource works primarily with `DatasourcePreExecute` at which point it generates the datasource. Association output only appends the data within `DatasourcePostExecute` running a delegate to check for a difference in XML output is highly inefficient, it's better to have Association Output trigger a delegate when it actually adds data to a datasource.

Also added check for addedAssociationOutput datasource param prior to adding any association data. This is used as a flag to confirm if the data is/has been generated. If the XML is a string, it does not mean that the output is cached, or vice versa, an extension might load the cache and serve an object anyway, so some kind of flag is required. I'm aware my suggestion might not be the best but not sure what would be most suitable.